### PR TITLE
Using GraalVM CE 1.0.0RC1 bits in the Travis Gate

### DIFF
--- a/.test.sh
+++ b/.test.sh
@@ -31,7 +31,7 @@ $GRAALBIN/node js/sieve.js 15
 mvn -q -f js/fromjava/pom.xml package exec:exec -Drepeat=15
 JAVA_HOME=$1 mvn -q -f js/fromjava/pom.xml package exec:exec -Drepeat=15
 
-$GRAALBIN/graalpython python/sieve.py 15
+$GRAALBIN/graalpython --jvm python/sieve.py 25
 
-$GRAALBIN/polyglot --file ruby+js/sieve.rb --eval js:count=15 --file ruby+js/sieve.js
+$GRAALBIN/polyglot --jvm --file ruby+js/sieve.rb --eval js:count=25 --file ruby+js/sieve.js
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: java
+sudo: false
+
+before_script:
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start || echo Without Xvfb
+  - wget https://github.com/oracle/graal/releases/download/vm-1.0.0-rc1/graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz
+  - tar fxvz graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz
+  - ./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.ruby
+  - ./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.R
+  - ./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.python
+script:
+  - ./.test.sh ./graalvm-1.0.0-rc1/
+os:
+- linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ before_script:
   - ./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.R
   - ./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.python
 script:
-  - ./.test.sh ./graalvm-1.0.0-rc1/
+  - ./.test.sh ./graalvm-1.0.0-rc1/ 2>&1 | grep -v ^Computed.*Last.*one
 os:
 - linux


### PR DESCRIPTION
Can we rely on the [graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz](https://github.com/oracle/graal/releases/download/vm-1.0.0-rc1/graalvm-ce-1.0.0-rc1-linux-amd64.tar.gz) URL being stable and use it in the gate?

Can we be sure that 
```
./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.ruby
./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.R
./graalvm-1.0.0-rc1/bin/gu install -c org.graalvm.python
```
will always download the same bits? E.g. we get always the same results?

@eregon @ansalond @sdedic @thomaswue