### PR TITLE
Debug the Java Sieve Project as native-image.

### DIFF
--- a/java/algorithm/nbactions.xml
+++ b/java/algorithm/nbactions.xml
@@ -44,6 +44,18 @@
                         <activatedProfile>native-image</activatedProfile>
                     </activatedProfiles>
                 </action>
+                <action>
+                    <actionName>debug</actionName>
+                    <displayName>Debug Native Executable</displayName>
+                    <goals>
+                        <goal>exec:exec@debug</goal>
+                    </goals>
+                    <properties>
+                    </properties>
+                    <activatedProfiles>
+                        <activatedProfile>native-image</activatedProfile>
+                    </activatedProfiles>
+                </action>
             </actions>
         </profile>
     </profiles>

--- a/java/algorithm/pom.xml
+++ b/java/algorithm/pom.xml
@@ -122,6 +122,18 @@
                                     <executable>${project.build.directory}/sieve</executable>
                                 </configuration>
                             </execution>
+                            <execution>
+                                <id>debug</id>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>gdb</executable>
+                                    <commandlineArgs>
+                                        --interpreter=mi ${project.build.directory}/sieve
+                                    </commandlineArgs>
+                                </configuration>
+                            </execution>
                         </executions>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Since d9a30a9127548ad3 we are able to build and execute the generated `sieve` native executable:
![obrazek](https://user-images.githubusercontent.com/26887752/113987797-1493c900-984f-11eb-8ade-9918c9d9e09a.png)
Make sure the project is set to use GraalVM 20.3 with native-image exectable installed and that you select the _native-image_ configuration in the toolbar choicebox.

After Build, or Clean and Build select Run and the native executable is going to be properly executed:
![obrazek](https://user-images.githubusercontent.com/26887752/113988090-5f154580-984f-11eb-977f-3c48de6a08ea.png)

The question for the pull request is: _Can we also get Debug working?_

CCing @sdedic & @entlicher & @jlahoda