### PR TITLE
Haskell version of the sieve

### DIFF
--- a/haskell/Filter.hs
+++ b/haskell/Filter.hs
@@ -1,4 +1,8 @@
-
+module Filter (
+    FingerTree,
+    emptyTree,
+    acceptAndAdd,
+) where
 
 data FingerTree a =
     Empty |
@@ -28,6 +32,8 @@ fromnode :: Node a -> [a]
 fromnode (Node2 x y) = [x, y]
 fromnode (Node3 x y z) = [x, y, z]
 
+emptyTree :: FingerTree a
+emptyTree = Empty
 
 append :: a -> FingerTree a -> FingerTree a
 append x Empty = Single x
@@ -51,3 +57,16 @@ aslist (Deep p t a) = (fromdigit p) ++ (listofa t) ++ (fromdigit a)
 
         listofa :: FingerTree (Node a) -> [a]
         listofa t = foldr (++) [] (listoflista t)
+
+
+acceptAndAdd :: Int -> FingerTree Int -> (Bool, FingerTree Int)
+acceptAndAdd n t = checkandadd primesupto
+    where
+        upto = floor (sqrt (fromIntegral n)) + 1
+        allprimes = aslist t
+        primesupto = filter (\x -> x < upto) allprimes
+        checkandadd :: [Int] -> (Bool, FingerTree Int)
+        checkandadd [] = (True, append n t)
+        checkandadd (h : r) = if rem n h == 0 then (False, t)
+            else checkandadd r
+

--- a/haskell/filter.hs
+++ b/haskell/filter.hs
@@ -1,0 +1,53 @@
+
+
+data FingerTree a =
+    Empty |
+    Single a |
+    Deep (Digit a) (FingerTree (Node a)) (Digit a)
+    deriving (Show)
+
+data Digit a =
+    One a |
+    Two a a |
+    Three a a a |
+    Four a a a a
+    deriving (Show)
+
+fromdigit :: Digit a -> [a]
+fromdigit (One x) = [x]
+fromdigit (Two x y) = [x, y]
+fromdigit (Three x y z) = [x, y, z]
+fromdigit (Four x y z v) = [x, y, z, v]
+
+data Node a =
+    Node2 a a |
+    Node3 a a a
+    deriving (Show)
+
+fromnode :: Node a -> [a]
+fromnode (Node2 x y) = [x, y]
+fromnode (Node3 x y z) = [x, y, z]
+
+
+append :: a -> FingerTree a -> FingerTree a
+append x Empty = Single x
+append x (Single e) = Deep (One e) Empty (One x)
+append x (Deep p t a) = case a of
+    One e -> Deep p t (Two e x)
+    Two e1 e2 -> Deep p t (Three e1 e2 x)
+    Three e1 e2 e3 -> Deep p t (Four e1 e2 e3 x)
+    Four e1 e2 e3 e4 -> Deep p (append (Node3 e1 e2 e3) t) (Two e4 x)
+
+aslist :: FingerTree a -> [a]
+aslist Empty = []
+aslist (Single e) = [e]
+aslist (Deep p t a) = (fromdigit p) ++ (listofa t) ++ (fromdigit a)
+    where
+        listofnodes :: FingerTree (Node a) -> [Node a]
+        listofnodes t = aslist t
+
+        listoflista :: FingerTree (Node a) -> [[a]]
+        listoflista t = map fromnode (listofnodes t)
+
+        listofa :: FingerTree (Node a) -> [a]
+        listofa t = foldr (++) [] (listoflista t)

--- a/haskell/sieve.hs
+++ b/haskell/sieve.hs
@@ -1,0 +1,13 @@
+import Filter (FingerTree, emptyTree, acceptAndAdd)
+
+natural :: [Int]
+natural = [2..]
+
+primes :: FingerTree Int -> [Int] -> [Int]
+primes t (n : r) = if found then (n : primes nt r) else primes t r
+    where
+        (found, nt) = acceptAndAdd n t
+primes _ [] = []
+
+main = print $ length (take 10000 (primes emptyTree natural))
+


### PR DESCRIPTION
Uses [FingerTree](https://en.wikipedia.org/wiki/Finger_tree) functional data structure instead of linked list. One can try my code as:
```bash
sieve/haskell$ ghc sieve.hs 
[1 of 2] Compiling Filter           ( Filter.hs, Filter.o )
[2 of 2] Compiling Main             ( sieve.hs, sieve.o )
Linking sieve ...
sieve/haskell$ time ./sieve 
10000
real    0m1,821s
user    0m1,745s
sys     0m0,076s
```
My C or JavaScript version can get below 50ms to compute 100000 prime numbers. Here even 10000 takes more than a second. What am I doing wrong? Anything obviously wrong? Is there a profiler for Haskell to use? 