### PR TITLE
Working Rust sieve under GraalVM.

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "rust"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,4 +5,7 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[profile.release]
+#panic = "abort"
+
 [dependencies]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "rust"
 version = "0.1.0"
-edition = "2021"
+edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [profile.release]
-#panic = "abort"
+panic = "abort"
 
 [dependencies]
+libc = "0.2"

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,56 @@
+# Running Rust
+
+Best way to install Rust would be using rustup (see your distro repository, or `https://rustup.rs`), it allows to install specific toolchains/rust versions, which might be important to match LLVM version with GraalVM.
+
+Toolchain installation:
+```sh
+rustup toolchain install stable
+rustup toolchain install 1.63
+```
+
+Then you can run the code just being in this directory:
+```sh
+cargo run --release
+cargo +1.63 run --release
+```
+(don't forget the release flag, unoptimized code can be more than 10 times slower with rust)
+
+# Running Rust with GraalVM
+The code is tested with specific versions:
+- rust 1.63
+- GraalVM EE Native 22.2.0
+	- it is not LTS version, because previous versions don't work with rust's standard main function.
+	- Though it is possible to start rust code using C-like main function without additional problems (see `#![no_main]`).
+
+With other versions it is advisable to match LLVM versions:
+```sh
+rustc +1.63 --version --verbose
+$GRAALVM/bin/lli --version
+```
+
+Running Rust under GraalVM should then be simple:
+```sh
+cargo +1.63 rustc --release -- --emit=llvm-bc
+$GRAALVM/bin/lli --lib (rustc +1.63 --print sysroot)/lib/libstd-* $RUST/target/release/deps/rust-*.bc
+```
+(in case of tinkering, you might want to check that there is only one `rust-*.bc` file)
+
+
+# Workarounds
+
+## std::time::Instant
+Usage of time measurements in std result in `com.oracle.truffle.api.CompilerDirectives$ShouldNotReachHere` with exact stack trace changing between GraalVM/Rust versions.
+
+Unclear why, the reimplementation in `time.rs` uses exact same call to libc as `std::time::Instant` would.
+
+## Unsuported instructions
+- `llvm.smul.with.overflow.i128` et al. are problematic only in debug mode which would normally panic on overflow. Fixed by using wrapping instructions.
+- `llvm.fptoui.sat.i32.f64` inability to convert floats to ints complicates `sqrt` computation -> `int_sqrt.rs`.
+
+# Performance oddities
+(All times are on the same machine, unspecified, only relative times are important)
+
+Using `cargo +1.63 run --release` one loop of 100 000 primes is completed in ~65 ms.
+
+GraalVM (EE Native 22.2.0) gives nondeterministic times. It converges to either ~100 ms or ~250 ms per loop, even with the exact same bitcode without rerunning:
+```cargo +1.63 rustc --release -- --emit=llvm-bc```

--- a/rust/src/collection.rs
+++ b/rust/src/collection.rs
@@ -1,0 +1,29 @@
+pub trait CollectionTrait<T>
+where
+    for<'a> &'a Self: IntoIterator<Item = &'a T>,
+{
+    fn new(value: T) -> Self;
+    fn push_back(&mut self, value: T);
+}
+
+impl<T> CollectionTrait<T> for std::collections::LinkedList<T> {
+    fn new(value: T) -> Self {
+        let mut c = Self::new();
+        c.push_back(value);
+        c
+    }
+    fn push_back(&mut self, value: T) {
+        Self::push_back(self, value)
+    }
+}
+
+impl<T> CollectionTrait<T> for Vec<T> {
+    fn new(value: T) -> Self {
+        let mut c = Self::new();
+        c.push_back(value);
+        c
+    }
+    fn push_back(&mut self, value: T) {
+        Self::push(self, value)
+    }
+}

--- a/rust/src/collection.rs
+++ b/rust/src/collection.rs
@@ -1,28 +1,18 @@
 pub trait CollectionTrait<T>
 where
     for<'a> &'a Self: IntoIterator<Item = &'a T>,
+    Self: Default,
 {
-    fn new(value: T) -> Self;
     fn push_back(&mut self, value: T);
 }
 
 impl<T> CollectionTrait<T> for std::collections::LinkedList<T> {
-    fn new(value: T) -> Self {
-        let mut c = Self::new();
-        c.push_back(value);
-        c
-    }
     fn push_back(&mut self, value: T) {
         Self::push_back(self, value)
     }
 }
 
 impl<T> CollectionTrait<T> for Vec<T> {
-    fn new(value: T) -> Self {
-        let mut c = Self::new();
-        c.push_back(value);
-        c
-    }
     fn push_back(&mut self, value: T) {
         Self::push(self, value)
     }

--- a/rust/src/int_sqrt.rs
+++ b/rust/src/int_sqrt.rs
@@ -1,0 +1,17 @@
+pub fn integer_sqrt(n: crate::Int) -> crate::Int {
+    // missing LLVM builtin: llvm.fptoui.sat.i32.f64
+    // return (n as f64).sqrt() as crate::Int;
+
+    let mut bit = (1 as crate::Int) << (std::mem::size_of::<crate::Int>() * 8 / 2 - 1);
+
+    let mut result = 0 as crate::Int;
+    while bit != 0 {
+        if n >= (result + bit) * (result + bit) {
+            result += bit;
+        }
+
+        bit = bit >> 1;
+    }
+
+    result
+}

--- a/rust/src/list.rs
+++ b/rust/src/list.rs
@@ -1,0 +1,76 @@
+// Quick own implementation of linked list - as with most datastructures "unsafe" code is required for performant/straightforward implementation.
+// But the interface is safe - no UB can be caused by using this interface.
+
+use std::ptr::NonNull;
+
+struct Node<T> {
+    next: Option<NonNull<Self>>,
+    value: T,
+}
+
+impl<T> Node<T> {
+    fn new_ptr(value: T) -> NonNull<Self> {
+        unsafe { NonNull::new_unchecked(Box::into_raw(Box::new(Node { next: None, value }))) }
+    }
+}
+
+pub struct NodeIterator<'a, T> {
+    node: Option<&'a Node<T>>,
+}
+
+impl<'a, T> Iterator for NodeIterator<'a, T> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<Self::Item> {
+        let node = self.node?;
+        self.node = node.next.map(|r| unsafe { r.as_ref() });
+        Some(&node.value)
+    }
+}
+
+pub struct List<T> {
+    first: NonNull<Node<T>>,
+    last: NonNull<Node<T>>,
+}
+
+impl<'a, T> IntoIterator for &'a List<T> {
+    type Item = &'a T;
+    type IntoIter = NodeIterator<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        NodeIterator {
+            node: Some(unsafe { self.first.as_ref() }),
+        }
+    }
+}
+
+impl<T> crate::collection::CollectionTrait<T> for List<T> {
+    fn new(starting: T) -> Self {
+        let ptr = Node::new_ptr(starting);
+        Self {
+            first: ptr,
+            last: ptr,
+        }
+    }
+
+    fn push_back(&mut self, value: T) {
+        let ptr = Node::new_ptr(value);
+        unsafe { self.last.as_mut() }.next = Some(ptr);
+        self.last = ptr;
+    }
+}
+
+impl<T> Drop for List<T> {
+    fn drop(&mut self) {
+        let mut node_ptr = self.first.as_ptr();
+        loop {
+            let next_ptr = unsafe { (*node_ptr).next };
+
+            //dealloc
+            unsafe { Box::from_raw(node_ptr) };
+
+            match next_ptr {
+                Some(next_ptr) => node_ptr = next_ptr.as_ptr(),
+                None => break,
+            }
+        }
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -17,9 +17,12 @@ impl Default for Natural {
     }
 }
 
-impl Natural {
-    fn next(&self) -> Self {
-        Self { cnt: self.cnt + 1 }
+impl Iterator for Natural {
+    type Item = Int;
+    fn next(&mut self) -> Option<Self::Item> {
+        let old = self.cnt;
+        self.cnt += 1;
+        Some(old)
     }
 }
 
@@ -33,21 +36,16 @@ struct Filter {
 
 impl Filter {
     fn divides(&self, number: Int) -> bool {
-        number % self.prime == 0
+        self.prime != 0 && number % self.prime == 0
     }
 }
 
+#[derive(Default)]
 struct Filters {
     filters: Collection<Filter>,
 }
 
 impl Filters {
-    fn new() -> Self {
-        Self {
-            filters: <Collection<Filter> as CollectionTrait<Filter>>::new(Filter { prime: 2 }),
-        }
-    }
-
     fn accept_and_add(&mut self, number: Int) -> bool {
         let upto = (number as f32).sqrt() as Int;
         let res = !(&self.filters)
@@ -61,34 +59,26 @@ impl Filters {
     }
 }
 
+#[derive(Default)]
 struct Primes {
     natural: Natural,
     filters: Filters,
 }
 
-impl Default for Primes {
-    fn default() -> Self {
-        Self {
-            natural: Natural::default(),
-            filters: Filters::new(),
-        }
-    }
-}
-
 impl Primes {
     fn next(&mut self) -> Int {
-        loop {
-            self.natural = self.natural.next();
-
-            if self.filters.accept_and_add(self.natural.cnt) {
-                break self.natural.cnt;
+        while let Some(cnt) = self.natural.next() {
+            if self.filters.accept_and_add(cnt) {
+                return cnt;
             }
         }
+        // should never happen
+        0
     }
 
     fn compute(&mut self) -> Int {
         let start = Instant::now();
-        let mut cnt = 1;
+        let mut cnt = 0;
         let mut prnt_cnt = 97;
         loop {
             let res = self.next();

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,121 @@
+use std::time::Instant;
+
+mod collection;
+mod list;
+
+use collection::CollectionTrait;
+
+type Int = u32;
+
+struct Natural {
+    cnt: Int,
+}
+
+impl Default for Natural {
+    fn default() -> Self {
+        Self { cnt: 2 }
+    }
+}
+
+impl Natural {
+    fn next(&self) -> Self {
+        Self { cnt: self.cnt + 1 }
+    }
+}
+
+//type Collection<T> = Vec<T>;
+//type Collection<T> = std::collections::LinkedList<T>;
+type Collection<T> = list::List<T>;
+
+struct Filter {
+    prime: Int,
+}
+
+impl Filter {
+    fn divides(&self, number: Int) -> bool {
+        number % self.prime == 0
+    }
+}
+
+struct Filters {
+    filters: Collection<Filter>,
+}
+
+impl Filters {
+    fn new() -> Self {
+        Self {
+            filters: <Collection<Filter> as CollectionTrait<Filter>>::new(Filter { prime: 2 }),
+        }
+    }
+
+    fn accept_and_add(&mut self, number: Int) -> bool {
+        let upto = (number as f32).sqrt() as Int;
+        let res = !(&self.filters)
+            .into_iter()
+            .take_while(|f| f.prime <= upto)
+            .any(|f| f.divides(number));
+        if res {
+            self.filters.push_back(Filter { prime: number });
+        }
+        res
+    }
+}
+
+struct Primes {
+    natural: Natural,
+    filters: Filters,
+}
+
+impl Default for Primes {
+    fn default() -> Self {
+        Self {
+            natural: Natural::default(),
+            filters: Filters::new(),
+        }
+    }
+}
+
+impl Primes {
+    fn next(&mut self) -> Int {
+        loop {
+            self.natural = self.natural.next();
+
+            if self.filters.accept_and_add(self.natural.cnt) {
+                break self.natural.cnt;
+            }
+        }
+    }
+
+    fn compute(&mut self) -> Int {
+        let start = Instant::now();
+        let mut cnt = 1;
+        let mut prnt_cnt = 97;
+        loop {
+            let res = self.next();
+            cnt += 1;
+            if cnt % prnt_cnt == 0 {
+                println!(
+                    "Computed {cnt} primes in {} ms. Last one is {res}",
+                    (Instant::now() - start).as_millis()
+                );
+                prnt_cnt *= 2;
+            }
+            if cnt >= 100000 {
+                break res;
+            }
+        }
+    }
+}
+
+fn main() {
+    loop {
+        let mut p = Primes::default();
+        let start = Instant::now();
+        let value = p.compute();
+        let took = Instant::now() - start;
+        println!(
+            "Hundred thousand primes computed in {} ms",
+            took.as_millis(),
+        );
+    }
+}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,111 +1,24 @@
-use std::time::Instant;
-
 mod collection;
+mod int_sqrt;
 mod list;
+mod primes;
+mod time;
 
-use collection::CollectionTrait;
+//type Instant = std::time::Instant;
+type Instant = time::Instant;
+
+use primes::Primes;
 
 type Int = u32;
-
-struct Natural {
-    cnt: Int,
-}
-
-impl Default for Natural {
-    fn default() -> Self {
-        Self { cnt: 2 }
-    }
-}
-
-impl Iterator for Natural {
-    type Item = Int;
-    fn next(&mut self) -> Option<Self::Item> {
-        let old = self.cnt;
-        self.cnt += 1;
-        Some(old)
-    }
-}
-
-//type Collection<T> = Vec<T>;
-//type Collection<T> = std::collections::LinkedList<T>;
-type Collection<T> = list::List<T>;
-
-struct Filter {
-    prime: Int,
-}
-
-impl Filter {
-    fn divides(&self, number: Int) -> bool {
-        self.prime != 0 && number % self.prime == 0
-    }
-}
-
-#[derive(Default)]
-struct Filters {
-    filters: Collection<Filter>,
-}
-
-impl Filters {
-    fn accept_and_add(&mut self, number: Int) -> bool {
-        let upto = (number as f32).sqrt() as Int;
-        let res = !(&self.filters)
-            .into_iter()
-            .take_while(|f| f.prime <= upto)
-            .any(|f| f.divides(number));
-        if res {
-            self.filters.push_back(Filter { prime: number });
-        }
-        res
-    }
-}
-
-#[derive(Default)]
-struct Primes {
-    natural: Natural,
-    filters: Filters,
-}
-
-impl Primes {
-    fn next(&mut self) -> Int {
-        while let Some(cnt) = self.natural.next() {
-            if self.filters.accept_and_add(cnt) {
-                return cnt;
-            }
-        }
-        // should never happen
-        0
-    }
-
-    fn compute(&mut self) -> Int {
-        let start = Instant::now();
-        let mut cnt = 0;
-        let mut prnt_cnt = 97;
-        loop {
-            let res = self.next();
-            cnt += 1;
-            if cnt % prnt_cnt == 0 {
-                println!(
-                    "Computed {cnt} primes in {} ms. Last one is {res}",
-                    (Instant::now() - start).as_millis()
-                );
-                prnt_cnt *= 2;
-            }
-            if cnt >= 100000 {
-                break res;
-            }
-        }
-    }
-}
 
 fn main() {
     loop {
         let mut p = Primes::default();
         let start = Instant::now();
-        let value = p.compute();
+        let _value = p.compute();
         let took = Instant::now() - start;
-        println!(
-            "Hundred thousand primes computed in {} ms",
-            took.as_millis(),
-        );
+        let millis = took.as_millis();
+
+        println!("Hundred thousand primes computed in {} ms", millis,);
     }
 }

--- a/rust/src/primes.rs
+++ b/rust/src/primes.rs
@@ -1,0 +1,96 @@
+use crate::collection::CollectionTrait;
+
+use crate::Instant;
+use crate::Int;
+
+struct Natural {
+    cnt: Int,
+}
+
+impl Default for Natural {
+    fn default() -> Self {
+        Self { cnt: 2 }
+    }
+}
+
+impl Iterator for Natural {
+    type Item = Int;
+    fn next(&mut self) -> Option<Self::Item> {
+        let old = self.cnt;
+        self.cnt += 1;
+        Some(old)
+    }
+}
+
+//type Collection<T> = Vec<T>;
+//type Collection<T> = std::collections::LinkedList<T>;
+type Collection<T> = crate::list::List<T>;
+
+struct Filter {
+    prime: Int,
+}
+
+impl Filter {
+    fn divides(&self, number: Int) -> bool {
+        self.prime != 0 && number % self.prime == 0
+    }
+}
+
+#[derive(Default)]
+struct Filters {
+    filters: Collection<Filter>,
+}
+
+impl Filters {
+    fn accept_and_add(&mut self, number: Int) -> bool {
+        let upto = crate::int_sqrt::integer_sqrt(number);
+        let res = !(&self.filters)
+            .into_iter()
+            .take_while(|f| f.prime <= upto)
+            .any(|f| f.divides(number));
+        if res {
+            self.filters.push_back(Filter { prime: number });
+        }
+        res
+    }
+}
+
+#[derive(Default)]
+pub struct Primes {
+    natural: Natural,
+    filters: Filters,
+}
+
+impl Primes {
+    fn next(&mut self) -> Int {
+        while let Some(cnt) = self.natural.next() {
+            if self.filters.accept_and_add(cnt) {
+                return cnt;
+            }
+        }
+        // should never happen
+        0
+    }
+
+    pub fn compute(&mut self) -> Int {
+        let start = Instant::now();
+        let mut cnt = 0;
+        let mut prnt_cnt = 97;
+        loop {
+            let res = self.next();
+            cnt += 1;
+            if cnt % prnt_cnt == 0 {
+                println!(
+                    "Computed {} primes in {} ms. Last one is {}",
+                    cnt,
+                    (Instant::now() - start.clone()).as_millis(),
+                    res,
+                );
+                prnt_cnt *= 2;
+            }
+            if cnt >= 100000 {
+                break res;
+            }
+        }
+    }
+}

--- a/rust/src/time.rs
+++ b/rust/src/time.rs
@@ -1,0 +1,47 @@
+// using wrapping versions of instructions, because with debug mode and GraalVM:
+// missing LLVM builtin: llvm.smul.with.overflow.i128
+// and it is not possible to overflow anyway
+
+#[derive(Clone)]
+pub struct Instant {
+    us: i128,
+}
+
+impl Instant {
+    pub fn now() -> Self {
+        let mut s = libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        };
+        let err = unsafe { libc::gettimeofday(&mut s, std::ptr::null_mut()) };
+        if err == -1 {
+            panic!("libc::gettimeofday error");
+        }
+
+        Self {
+            us: (s.tv_sec as i128)
+                .wrapping_mul(1_000_000)
+                .wrapping_add(s.tv_usec as i128),
+        }
+    }
+}
+
+impl std::ops::Sub for Instant {
+    type Output = Duration;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Duration {
+            us: (self.us.wrapping_sub(rhs.us)) as u128,
+        }
+    }
+}
+
+pub struct Duration {
+    us: u128,
+}
+
+impl Duration {
+    pub fn as_millis(&self) -> u128 {
+        self.us / 1000
+    }
+}


### PR DESCRIPTION
Though there is interesting nondeterminism of optimalizations - GraalVM converges to either ~100 ms or ~250 ms per loop.
(while `cargo run --release` is ~65 ms)